### PR TITLE
Made public methods of CircuitBreaker virtual 

### DIFF
--- a/src/CircuitBreaker.Net/CircuitBreaker.cs
+++ b/src/CircuitBreaker.Net/CircuitBreaker.cs
@@ -41,28 +41,28 @@ namespace CircuitBreaker.Net
             _currentState = _closedState;
         }
 
-        public void Execute(Action action)
+        public virtual void Execute(Action action)
         {
             if (action == null) throw new ArgumentNullException("action");
 
             _currentState.Invoke(action);
         }
 
-        public T Execute<T>(Func<T> func)
+        public virtual T Execute<T>(Func<T> func)
         {
             if (func == null) throw new ArgumentNullException("func");
             
             return _currentState.Invoke(func);
         }
 
-        public async Task ExecuteAsync(Func<Task> func)
+        public virtual async Task ExecuteAsync(Func<Task> func)
         {
             if (func == null) throw new ArgumentNullException("func");
 
             await _currentState.InvokeAsync(func);
         }
 
-        public async Task<T> ExecuteAsync<T>(Func<Task<T>> func)
+        public virtual async Task<T> ExecuteAsync<T>(Func<Task<T>> func)
         {
             if (func == null) throw new ArgumentNullException("func");
 


### PR DESCRIPTION
Hi Alexandr,

Hope you don't mind that I send you a pull request out of the blue :). But it would be really nice if the public methods of the CircuitBreaker class would be virtual. That way people can customize the way they use your library by a great amount.

If you have any questions or you want me to edit the pull request I'm glad to discuss this with you.

For example to implement logging:

``` csharp
public interface ICustomCircuitBreaker: ICircuitBreaker
{
}

public class CustomCircuitBreaker : CircuitBreaker.Net.CircuitBreaker, ICustomCircuitBreaker
{
    public DefaultCircuitBreaker()
        : base(TaskScheduler.Default,
            maxFailures: 2,
            invocationTimeout: TimeSpan.FromMilliseconds(10),
            circuitResetTimeout: TimeSpan.FromMilliseconds(1000))
    {
    }

    public override void Execute(Action action)
    {
        try
        {
            base.Exectue(action);
        }
        catch (CircuitBreakerTimeoutException)
        {
            this._mylogger("CircuitBreaker timeout occured");
            throw;
        }
        catch
        {
            throw;
        }
    }
}
```
