### PR TITLE
Call ICircuitBreakerEvents on state change 

### DIFF
--- a/src/CircuitBreaker.Net/CircuitBreaker.cs
+++ b/src/CircuitBreaker.Net/CircuitBreaker.cs
@@ -14,14 +14,11 @@ namespace CircuitBreaker.Net
 
         private ICircuitBreakerState _currentState;
 
-        private ICircuitBreakerEvents _circuitBreakerEventHandler;
-
         public CircuitBreaker(
             TaskScheduler taskScheduler,
             int maxFailures,
             TimeSpan invocationTimeout,
-            TimeSpan circuitResetTimeout,
-            ICircuitBreakerEvents eventHandler = null)
+            TimeSpan circuitResetTimeout)
         {
             var invoker = new CircuitBreakerInvoker(taskScheduler);
 
@@ -42,8 +39,9 @@ namespace CircuitBreaker.Net
                 circuitResetTimeout);
 
             _currentState = _closedState;
-            _circuitBreakerEventHandler = eventHandler;
         }
+
+        public ICircuitBreakerEvents CircuitBreakerEventHandler { get; set; }
 
         public virtual void Execute(Action action)
         {
@@ -75,17 +73,17 @@ namespace CircuitBreaker.Net
 
         void ICircuitBreakerSwitch.AttemptToCloseCircuit(ICircuitBreakerState from)
         {
-            if (Trip(from, _halfOpenedState)) _circuitBreakerEventHandler?.CircuitHalfOpened(this);
+            if (Trip(from, _halfOpenedState)) CircuitBreakerEventHandler?.CircuitHalfOpened(this);
         }
 
         void ICircuitBreakerSwitch.CloseCircuit(ICircuitBreakerState from)
         {
-            if (Trip(from, _closedState)) _circuitBreakerEventHandler?.CircuitClosed(this);
+            if (Trip(from, _closedState)) CircuitBreakerEventHandler?.CircuitClosed(this);
         }
 
         void ICircuitBreakerSwitch.OpenCircuit(ICircuitBreakerState from)
         {
-            if (Trip(from, _openedState)) _circuitBreakerEventHandler?.CircuitOpened(this);
+            if (Trip(from, _openedState)) CircuitBreakerEventHandler?.CircuitOpened(this);
         }
 
         private bool Trip(ICircuitBreakerState from, ICircuitBreakerState to)

--- a/src/CircuitBreaker.Net/CircuitBreaker.cs
+++ b/src/CircuitBreaker.Net/CircuitBreaker.cs
@@ -75,17 +75,17 @@ namespace CircuitBreaker.Net
 
         void ICircuitBreakerSwitch.AttemptToCloseCircuit(ICircuitBreakerState from)
         {
-            if (Trip(from, _halfOpenedState)) _circuitBreakerEventHandler.CircuitHalfOpened(this);
+            if (Trip(from, _halfOpenedState)) _circuitBreakerEventHandler?.CircuitHalfOpened(this);
         }
 
         void ICircuitBreakerSwitch.CloseCircuit(ICircuitBreakerState from)
         {
-            if (Trip(from, _closedState)) _circuitBreakerEventHandler.CircuitClosed(this);
+            if (Trip(from, _closedState)) _circuitBreakerEventHandler?.CircuitClosed(this);
         }
 
         void ICircuitBreakerSwitch.OpenCircuit(ICircuitBreakerState from)
         {
-            if (Trip(from, _openedState)) _circuitBreakerEventHandler.CircuitOpened(this);
+            if (Trip(from, _openedState)) _circuitBreakerEventHandler?.CircuitOpened(this);
         }
 
         private bool Trip(ICircuitBreakerState from, ICircuitBreakerState to)

--- a/src/CircuitBreaker.Net/ICircuitBreakerEvents.cs
+++ b/src/CircuitBreaker.Net/ICircuitBreakerEvents.cs
@@ -4,8 +4,8 @@ namespace CircuitBreaker.Net
 {
     public interface ICircuitBreakerEvents
     {
-        event EventHandler Closed;
-        event EventHandler Opened;
-        event EventHandler HalfOpened;
+        void CircuitClosed(ICircuitBreaker circuitBreaker);
+        void CircuitOpened(ICircuitBreaker circuitBreaker);
+        void CircuitHalfOpened(ICircuitBreaker circuitBreaker);
     }
 }


### PR DESCRIPTION
Added ICircuitBreakerEvents as a parameter to the CircuitBreaker ctor, with a default value of null.
Added calls to the ICircuitBreakerEvents instance, if set, after the calls to Trip, if Trip indicates it changed states.