### PR TITLE
Added more constructors to CircuitBreaker Exceptions to set inner exc…

### DIFF
--- a/src/CircuitBreaker.Net/CircuitBreakerInvoker.cs
+++ b/src/CircuitBreaker.Net/CircuitBreakerInvoker.cs
@@ -103,9 +103,13 @@ namespace CircuitBreaker.Net
             }
 
             tokenSource.Cancel();
-            throw new CircuitBreakerTimeoutException();
+
+            if (task.IsFaulted)
+                throw new CircuitBreakerOpenException(task.Exception);
+            else
+                throw new CircuitBreakerTimeoutException();
         }
-        
+
 
         private async Task InvokeAsync(Func<Task> func, TimeSpan timeout)
         {
@@ -133,7 +137,11 @@ namespace CircuitBreaker.Net
             }
 
             tokenSource.Cancel();
-            throw new CircuitBreakerTimeoutException();
+
+            if (task.IsFaulted)
+                throw new CircuitBreakerOpenException(task.Exception);
+            else
+                throw new CircuitBreakerTimeoutException();
         }
     }
 }

--- a/src/CircuitBreaker.Net/Exceptions/CircuitBreakerException.cs
+++ b/src/CircuitBreaker.Net/Exceptions/CircuitBreakerException.cs
@@ -4,5 +4,11 @@ namespace CircuitBreaker.Net.Exceptions
 {
     public abstract class CircuitBreakerException : Exception
     {
+        public CircuitBreakerException()
+        {
+        }
+        public CircuitBreakerException(string message, Exception inner): base(message, inner)
+        {
+        }
     }
 }

--- a/src/CircuitBreaker.Net/Exceptions/CircuitBreakerOpenException.cs
+++ b/src/CircuitBreaker.Net/Exceptions/CircuitBreakerOpenException.cs
@@ -4,5 +4,16 @@ namespace CircuitBreaker.Net.Exceptions
 {
     public class CircuitBreakerOpenException : CircuitBreakerException
     {
+        public CircuitBreakerOpenException()
+        {
+        }
+        public CircuitBreakerOpenException(Exception inner) : base("Openning CircuitBreaker failed", inner)
+        {
+
+        }
+        public CircuitBreakerOpenException(string message, Exception inner) : base(message, inner)
+        {
+
+        }
     }
 }

--- a/src/CircuitBreaker.Net/Exceptions/CircuitBreakerTimeoutException.cs
+++ b/src/CircuitBreaker.Net/Exceptions/CircuitBreakerTimeoutException.cs
@@ -4,5 +4,16 @@ namespace CircuitBreaker.Net.Exceptions
 {
     public class CircuitBreakerTimeoutException : CircuitBreakerException
     {
+        public CircuitBreakerTimeoutException()
+        {
+        }
+        public CircuitBreakerTimeoutException(Exception inner) : base("CircuitBreaker timed out", inner)
+        {
+
+        }
+        public CircuitBreakerTimeoutException(string message, Exception inner) : base(message, inner)
+        {
+
+        }
     }
 }

--- a/src/CircuitBreaker.Net/TaskExtensions.cs
+++ b/src/CircuitBreaker.Net/TaskExtensions.cs
@@ -86,7 +86,10 @@ namespace CircuitBreaker.Net
             if (timeout == TimeSpan.Zero)
             {
                 // We've already timed out.
-                tcs.SetException(new CircuitBreakerTimeoutException());
+                if (task.IsFaulted)
+                    tcs.SetException(new CircuitBreakerOpenException(task.Exception));
+                else
+                    tcs.SetException(new CircuitBreakerTimeoutException());
                 return tcs.Task;
             }
 

--- a/tests/CircuitBreaker.Net.Tests/CircuitBreakerInvokerTests.cs
+++ b/tests/CircuitBreaker.Net.Tests/CircuitBreakerInvokerTests.cs
@@ -43,7 +43,22 @@ namespace CircuitBreaker.Net.Tests
                 Assert.ThrowsAny<Exception>(() => _sut.InvokeThrough(state, () => { throw new Exception(); }, TimeSpan.FromMilliseconds(100)));
                 state.Received().InvocationFails();
             }
-
+            [Fact]
+            public void ExepectOpenExceptionWhenActionFails()
+            {
+                var state = Substitute.For<ICircuitBreakerState>();
+                var e = Assert.ThrowsAny<Exception>(() => _sut.InvokeThrough(state, () => { throw new Exception(); }, TimeSpan.FromMilliseconds(100)));
+                state.Received().InvocationFails();
+                Assert.IsType<Exceptions.CircuitBreakerOpenException>(e);
+            }
+            [Fact]
+            public void ExepectInnerExceptionWhenActionFails()
+            {
+                var state = Substitute.For<ICircuitBreakerState>();
+                var e = Assert.ThrowsAny<Exception>(() => _sut.InvokeThrough(state, () => { throw new ArgumentNullException(); }, TimeSpan.FromMilliseconds(100)));
+                state.Received().InvocationFails();
+                Assert.IsType<ArgumentNullException>(e.InnerException.InnerException);
+            }
             [Fact]
             public void ActionSucceessfulInvocation()
             {


### PR DESCRIPTION
When the task employed in CircuitBreakerInvoker.Invoke() for executing given action fails and its Status is IsFaulted, we need to pass task.Exception to the new CircuitBreaker exception we want to throw so that it is set in its InnerException. Otherwise we will lose the real exception and the user who used CircuitBreaker will not know what the source of failure was.